### PR TITLE
Fix PHPUnit framework exceptions

### DIFF
--- a/Test/Case/Controller/Component/Auth/AclAuthorizeTest.php
+++ b/Test/Case/Controller/Component/Auth/AclAuthorizeTest.php
@@ -17,6 +17,7 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+App::uses('Controller', 'Controller');
 App::uses('AclAuthorize', 'Authorize.Controller/Component/Auth');
 App::uses('ComponentCollection', 'Controller');
 App::uses('AclComponent', 'Controller/Component');


### PR DESCRIPTION
PHPUnit is unable to retrieve the typehints for `AclComponent::init()` and `ComponentCollection::init()` unless the class being hinted (in this case `Controller`) is available. Simply calling `App::uses()` on `Controller` thus fixes these two exceptions.
